### PR TITLE
Fix race condition of `state_folders` name

### DIFF
--- a/gpb/utils/clean.py
+++ b/gpb/utils/clean.py
@@ -4,7 +4,7 @@ import json
 from datetime import datetime
 
 def clean_create_folder(command, gpo_guid):
-    state_folder = datetime.now().strftime("%Y_%m_%d_%H%M%S")
+    state_folder = datetime.now().strftime("%Y_%m_%d_%H%M%S_%f")
     os.makedirs("state_folders", exist_ok=True)
     os.makedirs(os.path.join("state_folders", state_folder))
     os.makedirs(os.path.join("state_folders", state_folder, "revert"))


### PR DESCRIPTION
I've discovered a race condition on state folders' creation when 2 script instances were running at almost the same time.

The previous command wasn't able to remove its state folder in time before the next command creates it, causing the next command fails to create a state folder.

- Before fix

<img width="1228" height="1018" alt="image" src="https://github.com/user-attachments/assets/e5ca0005-a198-4f8e-a5ae-ca28ae31c4fc" />

- After fix

<img width="2095" height="1663" alt="WindowsTerminal_VsZR9Q3bXk" src="https://github.com/user-attachments/assets/86905553-d745-40d4-8439-b72653794c9b" />
